### PR TITLE
[은진] 마이페이지, 메인페이지 프로젝트 관련 기능 업데이트

### DIFF
--- a/src/components/user/ProjectPreview.tsx
+++ b/src/components/user/ProjectPreview.tsx
@@ -1,14 +1,16 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { ReactComponent as TeamProfile } from '../../assets/MainAvatar.svg';
-import EX from '../../assets/eximage.png';
 import { LinkText, ProjectContainer } from './UserStyle';
 import StarBorderRoundedIcon from '@mui/icons-material/StarBorderRounded';
 import Rating from '@mui/material/Rating';
 import StarRateRoundedIcon from '@mui/icons-material/StarRateRounded';
 import { styled } from 'styled-components';
+import { useAllProjectStore } from '../../states/user/UserProjectStore';
+import { FetchAllProject } from '../../services/MainPageApi';
 
 export default function ProjectPreview() {
+  const { content, setProjects } = useAllProjectStore();
   const StyledRating = styled(Rating)({
     '& .MuiRating-iconFilled': {
       color: 'black',
@@ -17,38 +19,54 @@ export default function ProjectPreview() {
       color: '#315af1',
     },
   });
+  useEffect(() => {
+    const fetchProjects = async () => {
+      try {
+        await FetchAllProject(0, 0);
+      } catch (error) {
+        console.error('프로젝트 데이터 가져오기 실패:', error);
+      }
+    };
+
+    fetchProjects();
+  }, [setProjects]);
   return (
     <div>
-      <ProjectContainer>
-        <div className="flex items-center mt-2 justify-between w-full">
-          <div className="flex items-center">
-            <TeamProfile />
-            <span className="flex-col ml-2">
-              <p className="text-lg">프로젝트 명</p>
-              <p className="text-base font-light" style={{ color: '#828282' }}>
-                Team : {}
-              </p>
-            </span>
+      {content.map(project => (
+        <ProjectContainer key={project.projectId}>
+          <div className="flex items-center mt-2 justify-between w-full">
+            <div className="flex items-center">
+              <TeamProfile />
+              <span className="flex-col ml-2">
+                <p className="text-lg">{project.title}</p>
+                <p className="text-base font-light" style={{ color: '#828282' }}>
+                  Team : {project.teamName}
+                </p>
+              </span>
+            </div>
           </div>
-          <StarBorderRoundedIcon fontSize="large" className="justify-end" />
-        </div>
-        <img src={EX} alt="My Project" className="mb-2" style={{ width: '270px' }} />
-        <div className="ml-3">
-          <p className="font-light text-lg">프로젝트 설명{}</p>
-          <div className="flex justify-between">
-            <StyledRating
-              defaultValue={2}
-              precision={0.5}
-              icon={<StarRateRoundedIcon fontSize="inherit" />}
-              emptyIcon={<StarBorderRoundedIcon fontSize="inherit" />}
-              readOnly
-            />
-            <Link to="/feedback">
-              <LinkText>피드백 참여하기 &gt;</LinkText>
-            </Link>
+          <img src={project.mainImageUrl} alt="My Project" className="mb-2" style={{ width: '270px' }} />
+          <div className="ml-3">
+            <p className="font-light text-lg">
+              {project.tags.map(tag => (
+                <div key={tag.tagId}>{tag.tagName}</div>
+              ))}
+            </p>
+            <div className="flex justify-between">
+              <StyledRating
+                defaultValue={project.score}
+                precision={0.5}
+                icon={<StarRateRoundedIcon fontSize="inherit" />}
+                emptyIcon={<StarBorderRoundedIcon fontSize="inherit" />}
+                readOnly
+              />
+              <Link to={`/feedback/projects/${project.projectId}`}>
+                <LinkText>피드백 참여하기 &gt;</LinkText>
+              </Link>
+            </div>
           </div>
-        </div>
-      </ProjectContainer>
+        </ProjectContainer>
+      ))}
     </div>
   );
 }

--- a/src/components/user/UserStyle.ts
+++ b/src/components/user/UserStyle.ts
@@ -4,7 +4,7 @@ import { ReactComponent as PointIcon } from '../../assets/Coin.svg';
 export const ProjectContainer = styled.div`
   border: none;
   border-radius: 15px;
-  padding: 3px;
+  padding: 0.5rem;
   width: max-content;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1), 0 6px 20px rgba(0, 0, 0, 0.1);
 `;

--- a/src/pages/user/mypage/MyPage.tsx
+++ b/src/pages/user/mypage/MyPage.tsx
@@ -45,6 +45,7 @@ import {
   EditNotion,
   FetchLogout,
   FetchMyPage,
+  RecentProject,
   SendQuest,
 } from '../../../services/UserApi';
 import { useUserStore } from '../../../states/user/UserStore';
@@ -58,6 +59,7 @@ import AIReport from '../../../components/utils/AIReport';
 import Tooltip, { TooltipProps, tooltipClasses } from '@mui/material/Tooltip';
 import { styled } from '@mui/material';
 import QuestSuccess from '../../../components/user/QuestSuccess';
+import { RecentProjectStore } from '../../../states/user/UserProjectStore';
 
 const LightTooltip = styled(({ className, ...props }: TooltipProps) => (
   <Tooltip {...props} classes={{ popper: className }} />
@@ -75,6 +77,7 @@ export default function MyPage() {
   const navigate = useNavigate();
   const userProfile = useUserStore(state => state.userProfile);
   const { setUserProfile } = useUserStore();
+  const LatestProject = RecentProjectStore();
   const [showLogoutAlert, setShowLogoutAlert] = useState(false);
   const [showEditNameAlert, setShowEditNameAlert] = useState(false);
   const [isEditingName, setIsEditingName] = useState(false);
@@ -104,6 +107,7 @@ export default function MyPage() {
   useEffect(() => {
     const fetchData = async () => {
       try {
+        await RecentProject();
         const userProfileData = await FetchMyPage();
         setUserProfile(userProfileData);
       } catch (error) {
@@ -535,20 +539,20 @@ export default function MyPage() {
           </div>
           <div className="flex ">
             <div className="flex-col">
-              <Link to="/createtest">
+              <Link to={`/createtest/${LatestProject.projectId}`}>
                 <LinkProject>
                   <div className="flex items-center gap-3">
                     <TeamProfile />
-                    <p className="text-lg">COCODAS</p>
+                    <p className="text-lg">{LatestProject.teamName}</p>
                   </div>
-                  <p className="text-gray-600 text-center mt-2">웹 IDE 프로젝트</p>
+                  <p className="text-gray-600 text-center mt-2">{LatestProject.title}</p>
                 </LinkProject>
               </Link>
               <FeedbackContainer>
                 <Link to="/feedback">
                   <TitleText className="mb-4">제출된 피드백</TitleText>
-                  <UniqueText className="mb-4">34</UniqueText>
-                  <DetailText>+ {} 34개의 피드백이 추가로 제출되었습니다.</DetailText>
+                  <UniqueText className="mb-4">{LatestProject.feedbackAmount}</UniqueText>
+                  <DetailText>{LatestProject.feedbackAmount}개의 피드백이 제출되었습니다.</DetailText>
                   <LinkText className="text-end">모아보기 &gt;</LinkText>
                 </Link>
               </FeedbackContainer>
@@ -557,7 +561,7 @@ export default function MyPage() {
               <TitleText>통계</TitleText>
               <UniqueText>평점</UniqueText>
               <UniqueText>{userProfile.statistic} % </UniqueText>
-              <DetailText>평점 4의 별점</DetailText>
+              <DetailText>평점 {LatestProject.score}의 별점</DetailText>
               <MypageChartIcon></MypageChartIcon>
             </StaticContainer>
             <AIReportContainer>

--- a/src/services/MainPageApi.ts
+++ b/src/services/MainPageApi.ts
@@ -1,0 +1,35 @@
+import { API_BASE_URL } from '../const/TokenApi';
+import { useAllProjectStore } from '../states/user/UserProjectStore';
+
+//메인 페이지 모든 프로젝트 요청
+export async function FetchAllProject(filter: number, page: number) {
+  try {
+    const response = await API_BASE_URL.get(`/api/projects?filter=${filter}&page=${page}`);
+    console.log('모든 프로젝트 요청 성공', response.data);
+    const projectData = {
+      totalPages: response.data.totalPages,
+      totalElements: response.data.totalElements,
+      first: response.data.first,
+      last: response.data.last,
+      size: response.data.size,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      content: response.data.content.map((project: any) => ({
+        projectId: project.projectId,
+        title: project.title,
+        teamName: project.teamName,
+        mainImageUrl: project.mainImageUrl,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        tags: project.tags.map((tag: any) => ({
+          tagId: tag.tagId,
+          tagName: tag.tagName,
+        })),
+        score: project.score,
+      })),
+    };
+    useAllProjectStore.getState().setProjects(projectData);
+    return projectData;
+  } catch (error) {
+    console.error('모든 프로젝트 요청 실패', error);
+    throw error;
+  }
+}

--- a/src/services/UserApi.ts
+++ b/src/services/UserApi.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { useCallback } from 'react';
 import { useUserStore } from '../states/user/UserStore';
 import { API_BASE_URL, KAKAO_ACCESS_TOKEN } from '../const/TokenApi';
+import { RecentProjectStore } from '../states/user/UserProjectStore';
 
 export async function FetchMyPage() {
   try {
@@ -190,3 +191,14 @@ export const SendQuest = async (sequence: string) => {
   }
   return false;
 };
+
+export async function RecentProject() {
+  try {
+    const response = await API_BASE_URL.get('/projects/my-recent-project');
+    console.log('최근 프로젝트 요청 성공', response.data);
+    RecentProjectStore.getState().setProjects(response.data);
+  } catch (error) {
+    console.error('최근 프로젝트 요청 실패', error);
+    throw error;
+  }
+}

--- a/src/states/user/UserProjectStore.tsx
+++ b/src/states/user/UserProjectStore.tsx
@@ -1,0 +1,51 @@
+import { create } from 'zustand';
+//메인페이지
+interface AllProjectState {
+  totalPages: number; //총 페이지 수
+  totalElements: number; //이건 총 몇 개인지 알려주는거
+  first: boolean; //첫 페이지 여부
+  last: boolean; //마지막 페이지 여부
+  size: number; // 한 페이지에 최대 몇 개 들어가는지
+  content: Content[];
+  setProjects: (projects: AllProjectState) => void;
+}
+interface Content {
+  projectId: number;
+  title: string;
+  teamName: string;
+  mainImageUrl: string;
+  tags: Tag[];
+  score: number;
+}
+interface Tag {
+  tagId: number;
+  tagName: string;
+}
+
+export const useAllProjectStore = create<AllProjectState>(set => ({
+  totalPages: 0,
+  totalElements: 0,
+  first: false,
+  last: false,
+  size: 0,
+  content: [],
+  setProjects: projects => set(projects),
+}));
+
+//마이페이지
+interface RecentProjectState {
+  projectId: number;
+  title: string;
+  teamName: string;
+  score: number;
+  feedbackAmount: number;
+  setProjects: (projects: RecentProjectState) => void;
+}
+export const RecentProjectStore = create<RecentProjectState>(set => ({
+  projectId: 0,
+  title: '',
+  teamName: '',
+  score: 0,
+  feedbackAmount: 0,
+  setProjects: projects => set(projects),
+}));

--- a/src/states/user/UserProjectStore.tsx
+++ b/src/states/user/UserProjectStore.tsx
@@ -1,14 +1,10 @@
 import { create } from 'zustand';
 //메인페이지
-interface AllProjectState {
-  totalPages: number; //총 페이지 수
-  totalElements: number; //이건 총 몇 개인지 알려주는거
-  first: boolean; //첫 페이지 여부
-  last: boolean; //마지막 페이지 여부
-  size: number; // 한 페이지에 최대 몇 개 들어가는지
-  content: Content[];
-  setProjects: (projects: AllProjectState) => void;
+interface Tag {
+  tagId: number;
+  tagName: string;
 }
+
 interface Content {
   projectId: number;
   title: string;
@@ -17,11 +13,19 @@ interface Content {
   tags: Tag[];
   score: number;
 }
-interface Tag {
-  tagId: number;
-  tagName: string;
+
+interface ProjectData {
+  totalPages: number;
+  totalElements: number;
+  first: boolean;
+  last: boolean;
+  size: number;
+  content: Content[];
 }
 
+interface AllProjectState extends ProjectData {
+  setProjects: (projects: ProjectData) => void;
+}
 export const useAllProjectStore = create<AllProjectState>(set => ({
   totalPages: 0,
   totalElements: 0,
@@ -29,7 +33,7 @@ export const useAllProjectStore = create<AllProjectState>(set => ({
   last: false,
   size: 0,
   content: [],
-  setProjects: projects => set(projects),
+  setProjects: projects => set(() => projects),
 }));
 
 //마이페이지


### PR DESCRIPTION
- 마이페이지 최근 프로젝트 정보 스토어 생성
- 요청 API 작성 후 마이페이지에서 상태 구독
- 메인 페이지 전체 프로젝트 정보 스토어 생성
- 요청 API 작성 후 메인페이지의 프로젝트 프리뷰 컴포넌트에 상태구독
- 추후 메인페이지에서 상태별 구분, 페이지네이션 추가 예정